### PR TITLE
Compile on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,19 @@ ifneq (,$(findstring Darwin,$(shell uname)))
 	MACOS = 1
 endif
 
+FREEBSD = 0
+ifneq (,$(findstring FreeBSD,$(shell uname)))
+        FREEBSD = 1
+	# System and ports clang do not have to be in the same path,
+	# so it depends on the CLANG_SUFFIX.
+	CLANG_SUFFIX ?= 
+	CLANG_PATH = $(shell which clang$(CLANG_SUFFIX))
+	CLANG_PREFIX = $(shell dirname $(CLANG_PATH))
+	CC = $(CLANG_PREFIX)/clang$(CLANG_SUFFIX)
+	CPP = $(CLANG_PREFIX)/clang++$(CLANG_SUFFIX)
+	CXX = $(CPP) 
+endif
+
 EXTRA_FLAGS += -DPOPCNT_CAPABILITY
 INC += -I third_party
 
@@ -138,6 +151,12 @@ BITS=32
 ifeq (x86_64,$(shell uname -m))
 BITS=64
 endif
+
+# FreeBSD uses "amd64" instead of "x86_64" 
+ifeq (amd64,$(shell uname -m))
+BITS=64
+endif
+
 # msys will always be 32 bit so look at the cpu arch instead.
 ifneq (,$(findstring AMD64,$(PROCESSOR_ARCHITEW6432)))
 	ifeq (1,$(MINGW))

--- a/hisat2
+++ b/hisat2
@@ -45,7 +45,7 @@ while (-f $prog && -l $prog){
 
 ($vol,$script_path,$prog) 
                 = File::Spec->splitpath($prog);
-my $os_is_nix   = ($^O eq "linux") || ($^O eq "darwin");
+my $os_is_nix   = ($^O eq "linux") || ($^O eq "darwin") || ($^O eq "freebsd");
 my $align_bin_s = $os_is_nix ? 'hisat2-align-s' : 'hisat2-align-s.exe'; 
 my $build_bin   = $os_is_nix ? 'hisat2-build' : 'hisat2-build.exe';               
 my $align_bin_l = $os_is_nix ? 'hisat2-align-l' : 'hisat2-align-l.exe'; 


### PR DESCRIPTION
In case you want them, these are the changes I had to do to make this compile and run on FreeBSD.

This fixes three separate issues:
1) It uses clang as CC, since that's the default compiler on FreeBSD i386 and amd64. 
I used the same prefix/suffix logic as for GCC, except that it has to handle how "clang" is typically in /usr/bin, but the suffixed versions (installed from packages) are typically in /usr/local/bin.
2) Handle uname -m returning "amd64" instead of "x86_64"
3) Detect freebsd as a nix-style OS in hisat2.

2 and 3 alone should be enough assuming you install gcc first - but the code compiles fine with clang, so that seems unnecessary. In the long run, I guess a cleaner solution would be to respect CC/CPP/CXX if those are set in the environment, and otherwise default to gcc/clang depending on either the OS or just which one is available.