### PR TITLE
Fix imp DeprecationWarning in hisat2-inspect

### DIFF
--- a/hisat2-inspect
+++ b/hisat2-inspect
@@ -21,7 +21,8 @@
 
 
 import os
-import imp
+import importlib
+from importlib.machinery import SourceFileLoader
 import inspect
 import logging
 
@@ -38,7 +39,7 @@ def main():
     curr_script           = os.path.realpath(inspect.getsourcefile(main))
     ex_path               = os.path.dirname(curr_script)
     inspect_bin_spec      = os.path.join(ex_path,inspect_bin_s)
-    bld                   = imp.load_source('hisat2-build',os.path.join(ex_path,'hisat2-build'))
+    bld                   = SourceFileLoader('hisat2-build',os.path.join(ex_path,'hisat2-build')).load_module()
     options,arguments     = bld.build_args()
 
     if '--verbose' in options:


### PR DESCRIPTION
To fix this deprecation warning:
```
/home/tools/hisat2-2.2.1/hisat2-inspect:24: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
```