### PR TITLE
SRA data access requires an additional library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,11 @@ SRA_LIB =
 SERACH_INC = 
 ifeq (1,$(USE_SRA))
 	SRA_DEF = -DUSE_SRA
-	SRA_LIB = -lncbi-ngs-c++-static -lngs-c++-static -lncbi-vdb-static -ldl
+	SRA_LIB = -lncbi-ngs-c++-static -lngs-c++-static
+	ifneq (,$(wildcard $(NCBI_VDB_DIR)/lib64/libncbi-ngs-static.a)) 
+		SRA_LIB += -lncbi-ngs-static
+	endif
+	SRA_LIB += -lncbi-vdb-static -ldl
 	SEARCH_INC += -I$(NCBI_NGS_DIR)/include -I$(NCBI_VDB_DIR)/include
 	SEARCH_LIBS += -L$(NCBI_NGS_DIR)/lib64 -L$(NCBI_VDB_DIR)/lib64
 endif


### PR DESCRIPTION
Starting with our next release 2.11.0, you will need to link against an additional library to build hisat2 with support of SRA data access.

We propose a change to your Makefile that should be completely transparent.
You can build it with our old -OR- new NGS package.

You can test it against our existing packages.
New packages for you to test are located in https://ftp-trace.ncbi.nlm.nih.gov/sra/ngs/2.11.0rc/