### PR TITLE
Add Github Actions based CI for Linux x86_64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      run:  make -j allall


### PR DESCRIPTION
Adds a CI check for Linux x86_64.

Related to https://github.com/DaehwanKimLab/hisat2/pull/251