### PR TITLE
Add CI for Linux aarch64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        submodules: recursive
 
     - name: Build
       run:  make -j allall
@@ -25,6 +27,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        submodules: recursive
 
     - name: Build on Linux ARM64
       uses: uraimo/run-on-arch-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      run:  make -j allall

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Linux x86_64
     runs-on: ubuntu-latest
 
     steps:
@@ -16,3 +17,26 @@ jobs:
 
     - name: Build
       run:  make -j allall
+
+  build-aarch64:
+    name: Linux aarch64
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build on Linux ARM64
+      uses: uraimo/run-on-arch-action@v2
+      with:
+        arch: aarch64
+        distro: ubuntu22.04
+        githubToken: ${{ github.token }}
+        dockerRunArgs: |
+          --volume "${PWD}:/hisat2"
+        install: |
+          apt-get update -q -y
+          apt-get install -q -y make g++
+        run: |
+          cd /hisat2
+          make -j allall


### PR DESCRIPTION
Adds a CI check for Linux ARM64. It uses QEMU for hardware emulation, so it is slower than the x86_64 build at Github Actions.

Must be merged after https://github.com/DaehwanKimLab/hisat2/pull/407 and https://github.com/DaehwanKimLab/hisat2/pull/251