### PR TITLE
Add Python3.12 support by removing use of the "imp" module

### DIFF
--- a/hisat2-inspect
+++ b/hisat2-inspect
@@ -21,10 +21,20 @@
 
 
 import os
-import imp
+import importlib.util
+import importlib.machinery
 import inspect
 import logging
 
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
 
 def main():
     logging.basicConfig(level=logging.ERROR,
@@ -38,7 +48,7 @@ def main():
     curr_script           = os.path.realpath(inspect.getsourcefile(main))
     ex_path               = os.path.dirname(curr_script)
     inspect_bin_spec      = os.path.join(ex_path,inspect_bin_s)
-    bld                   = imp.load_source('hisat2-build',os.path.join(ex_path,'hisat2-build'))
+    bld                   = load_source('hisat2-build',os.path.join(ex_path,'hisat2-build'))
     options,arguments     = bld.build_args()
 
     if '--verbose' in options:


### PR DESCRIPTION
Workaround is from https://docs.python.org/3.12/whatsnew/3.12.html#imp
