### PR TITLE
fix hisat2 performance: remove unused SpliceSiteDB from AlnSink

### DIFF
--- a/aln_sink.h
+++ b/aln_sink.h
@@ -671,14 +671,12 @@ public:
                      const StrList& refnames,
                      const StrList& repnames,
                      bool quiet,
-                     ALTDB<index_t>* altdb = NULL,
-                     SpliceSiteDB* ssdb = NULL) :
+                     ALTDB<index_t>* altdb = NULL) :
     oq_(oq),
     refnames_(refnames),
     repnames_(repnames),
     quiet_(quiet),
-    altdb_(altdb),
-    spliceSiteDB_(ssdb)
+    altdb_(altdb)
 	{ }
 
 	/**
@@ -954,7 +952,6 @@ protected:
 	bool               quiet_;        // true -> don't print alignment stats at the end
 	ReportingMetrics   met_;          // global repository of reporting metrics
     ALTDB<index_t>*    altdb_;
-    SpliceSiteDB*      spliceSiteDB_; //
 };
 
 /**
@@ -1524,15 +1521,13 @@ public:
                const StrList&   refnames,      // reference names
                const StrList&   repnames,      // repeat names
                bool             quiet,         // don't print alignment summary at end
-               ALTDB<index_t>*  altdb = NULL,
-               SpliceSiteDB*    ssdb  = NULL) :
+               ALTDB<index_t>*  altdb = NULL) :
 		AlnSink<index_t>(
                          oq,
                          refnames,
                          repnames,
                          quiet,
-                         altdb,
-                         ssdb),
+                         altdb),
     samc_(samc)
 	{ }
 	
@@ -1568,17 +1563,11 @@ public:
 			assert(flags1 != NULL);
 			appendMate(o, staln, *rd1, rd2, rdid, rs1, rs2, summ, ssm1, ssm2,
 			           *flags1, prm, mapq, sc);
-            if(rs1 != NULL && rs1->spliced() && this->spliceSiteDB_ != NULL) {
-                this->spliceSiteDB_->addSpliceSite(*rd1, *rs1);
-            }
 		}
 		if(rd2 != NULL && report2) {
 			assert(flags2 != NULL);
 			appendMate(o, staln, *rd2, rd1, rdid, rs2, rs1, summ, ssm2, ssm1,
 			           *flags2, prm, mapq, sc);
-            if(rs2 != NULL && rs2->spliced() && this->spliceSiteDB_ != NULL) {
-                this->spliceSiteDB_->addSpliceSite(*rd2, *rs2);
-            }
 		}
 	}
 

--- a/hisat2.cpp
+++ b/hisat2.cpp
@@ -4119,8 +4119,7 @@ static void driver(
                                                  refnames,     // reference names
                                                  repnames,     // repeat names
                                                  gQuiet,       // don't print alignment summary at end
-                                                 altdb,
-                                                 ssdb);
+                                                 altdb);
 				if(!samNoHead) {
 					bool printHd = true, printSq = true;
 					BTString buf;


### PR DESCRIPTION
improve perf scaling on large inputs (>1M reads) by not updating an unused sorted db for every align output

~~as far as i can tell, the SpliceSiteDB on `AlnSink` is written but never read from.~~
a similar record keeping structure exists on `AlnSinkWrap`, which may be in use.

SpliceSiteDB is updated for every aligned read reported to SAM (an output which is always generated?).  because SpliceSiteDB is backed by a red-black tree, every update is a log(n) tree traversal with a possible rearrangement... for large numbers of reads, maintaining the structure starts to show an obvious cost.

hisat2 version 2.2.1 from bioconda
for subsets of SRR12815479 on VectorBase-68_AaegyptiLVP_AGWG reference, on 8 cores, i observed the following times:

1,250 reads finished in 3.59s (0.3kread/s)
25,000 reads finished in 4.173s (5.9kread/s)
250,000 reads finished in 12.968s (19.2kread/s)
1,000,000 reads finished in 44s (**22.6kread/s**)
3,000,000 reads finished in 237s (**12.6kread/s**)
12,000,000 reads ran for over 3480+s (**<3.5kread/s**) before i gave up.

after this patch, i observe:
25,000 reads in 3.26s (7.7kread/s) (
1,000,000 reads in 28.74s (**34.8kread/s**) _(1.5x speedup)_
3,000,000 reads in 89.4s (**33.5kread/s**) _(2.65x speedup)_
12,000,000 reads in 313s (**38.3kread/s**) _(>10x speedup)_