### PR TITLE
Skip file existence check if stdin indicator exists

### DIFF
--- a/hisat2
+++ b/hisat2
@@ -320,6 +320,8 @@ if ((scalar(@read_files) > 0)
 sub check_file_exist($$$) {
 	my ($unps, $mate1s, $mate2s) = @_;
 	for my $fn (@$unps, @$mate1s, @$mate2s) {
+		# Skip existence check for stdin indicator
+		next if $fn eq '-';
 		if (not -f $fn) {
 			Fail("Read file '%s' doesn't exist\n", $fn);
 			return 1;


### PR DESCRIPTION
Hi HISAT2 team,

This addresses Issue #451, where piping reads to hisat2 aligner via stdin does not work. Please let me know if you have any questions, or if there are any checks you'd like me to perform regarding this!

Thanks,
John
